### PR TITLE
角色标签新增导演集&文件所属所有角色集，修改标头搜索条件展示逻辑

### DIFF
--- a/src/components/pageCom/headerSearchShowTag.vue
+++ b/src/components/pageCom/headerSearchShowTag.vue
@@ -20,9 +20,9 @@
             @close="closeTag(store.searchStore.searchCondition.starRating.value, key)" closable>
             {{ getStarRatingText(item) }}
         </el-tag>
-        <el-tag v-for="item, key in store.searchStore.searchCondition.performer.value" :key="key"
+        <el-tag v-for="item, key in store.searchStore.searchCondition.headerSearchPersonShow" :key="key"
             :type="tagType(store.searchStore.searchCondition.performer.logic)" size="large"
-            @close="closeTag(store.searchStore.searchCondition.performer.value, key)" closable>
+            @close="closeTag(store.searchStore.searchCondition.headerSearchPersonShow, key)" closable>
             {{ getPerformerText(item) }}
         </el-tag>
         <el-tag v-for="item, key in store.searchStore.searchCondition.cup.value" :key="key"

--- a/src/components/pageCom/tagBlock.vue
+++ b/src/components/pageCom/tagBlock.vue
@@ -63,15 +63,15 @@ const updateDeployableState = (deployableState: boolean) => {
 }
 
 const selectHandle = (val: never) => {
-    if (val == 'all') {
-        selectValArr.value = [];
+    const index = selectValArr.value.findIndex(item => item == val)
+    if (index > -1) {
+        selectValArr.value.splice(index, 1);
     } else {
-        if (searchLogic.value == EsearchLogic.single) {
-            selectValArr.value = [val];
+        if (val == 'all') {
+            selectValArr.value = [];
         } else {
-            const index = selectValArr.value.findIndex(item => item == val);
-            if (index > -1) {
-                selectValArr.value.splice(index, 1);
+            if (searchLogic.value == EsearchLogic.single) {
+                selectValArr.value = [val];
             } else {
                 selectValArr.value.push(val);
             }

--- a/src/dataInterface/common.interface.ts
+++ b/src/dataInterface/common.interface.ts
@@ -17,8 +17,10 @@ export interface IsearchCondition {
     year: IsearchConditionItem,
     starRating: IsearchConditionItem,
     performer: IsearchConditionItem,
+    director: IsearchConditionItem,
     cup: IsearchConditionItem,
     diyTag: { [key: string]: IsearchConditionItem },
+    headerSearchPersonShow: string[],
 }
 
 export interface IresUpdateDetailsView {

--- a/src/language/zhCn.ts
+++ b/src/language/zhCn.ts
@@ -93,6 +93,7 @@ export default {
         noStar: '未评分',
         star: '{star}星',
         noPerformer: '无{performer}',
+        directorBase: '导演集',
         admin: '标签管理',
         leftColumnDisplay: '左边栏显示',
         addClass: '添加标签分类',

--- a/src/serverData/resources.serverData.ts
+++ b/src/serverData/resources.serverData.ts
@@ -282,6 +282,7 @@ const resourcesSearchCondition = {
         CDB = this.setCDBGroupIssuingDate(CDB, 'issuingDate', searchCondition.year.logic, searchCondition.year.value);
         CDB = this.setCDBGroup(CDB, 'stars', searchCondition.starRating.logic, searchCondition.starRating.value);
         CDB = this.setCDBGroupPerformer(CDB, searchCondition.performer.logic, searchCondition.performer.value);
+        CDB = this.setCDBGroupDirctor(CDB, searchCondition.director.logic, searchCondition.director.value);
         CDB = this.setCDBGroupCup(CDB, searchCondition.cup.logic, searchCondition.cup.value);
         for (const key in searchCondition.diyTag) {
             CDB = this.setCDBGroupTag(CDB, key, searchCondition.diyTag[key].logic, searchCondition.diyTag[key].value);
@@ -354,6 +355,33 @@ const resourcesSearchCondition = {
             dataArr.forEach((item: string, index: number) => {
                 const boxName = "resPerformersId_" + index;
                 sqlArr.push(' (select count(*) from resourcesPerformers where  resources_id = resources.id and performer_id = @' + boxName + ') > 0');
+                perObj[boxName] = item;
+            });
+            _CDB.whereSql(sqlArr.join(' and '), perObj);
+        }
+        return _CDB;
+    },
+    setCDBGroupDirctor: function (_CDB: coreDBS, logic: EsearchLogic, dataArr: string[]) {
+        if (dataArr.length == 0) {
+            return _CDB;
+        }
+        if (logic == EsearchLogic.single) {
+            _CDB.whereSql("id in (select resources_id from resourcesDirectors where performer_id = @resPerformersId)", { resPerformersId: dataArr[0] });
+        } else if (logic == EsearchLogic.or) {
+            const sqlArr: Array<string> = [];
+            const perObj: { [key: string]: string } = {}
+            dataArr.forEach((item: string, index: number) => {
+                const boxName = "resPerformersId_" + index;
+                sqlArr.push("performer_id = @" + boxName)
+                perObj[boxName] = item;
+            })
+            _CDB.whereSql("id in (select resources_id from resourcesDirectors where " + sqlArr.join(' or ') + ")", perObj)
+        } else if (logic == EsearchLogic.and) {
+            const sqlArr: Array<string> = [];
+            const perObj: { [key: string]: string } = {}
+            dataArr.forEach((item: string, index: number) => {
+                const boxName = "resPerformersId_" + index;
+                sqlArr.push(' (select count(*) from resourcesDirectors where  resources_id = resources.id and performer_id = @' + boxName + ') > 0');
                 perObj[boxName] = item;
             });
             _CDB.whereSql(sqlArr.join(' and '), perObj);

--- a/src/store/search.store.ts
+++ b/src/store/search.store.ts
@@ -26,6 +26,10 @@ export const searchStore = defineStore('search', {
                 logic: EsearchLogic.single,
                 value: [],
             },
+            director: {
+                logic: EsearchLogic.single,
+                value: [],
+            },
             cup: {
                 logic: EsearchLogic.single,
                 value: [],
@@ -33,6 +37,7 @@ export const searchStore = defineStore('search', {
             diyTag: {
 
             },
+            headerSearchPersonShow: [],
         } as IsearchCondition,
     }),
     getters: {},
@@ -44,7 +49,9 @@ export const searchStore = defineStore('search', {
             this.searchCondition.year.value.splice(0);
             this.searchCondition.starRating.value.splice(0);
             this.searchCondition.performer.value.splice(0);
+            this.searchCondition.director.value.splice(0);
             this.searchCondition.cup.value.splice(0);
+            this.searchCondition.headerSearchPersonShow.splice(0);
             for (const key in this.searchCondition.diyTag) {
                 this.searchCondition.diyTag[key].value.splice(0);
             }
@@ -52,6 +59,11 @@ export const searchStore = defineStore('search', {
         setSearchText: function (str: string) {
             this.searchCondition.text = str;
         },
+
+        setPersonShow: function (dataVal: string[]) {
+            this.searchCondition.headerSearchPersonShow = dataVal
+        },
+
         setSearchData: function (mode: string, logic: EsearchLogic, dataVal: string[]) {
             switch (mode) {
                 case 'country':
@@ -77,6 +89,10 @@ export const searchStore = defineStore('search', {
                 case 'performer':
                     this.searchCondition.performer.logic = logic;
                     this.searchCondition.performer.value = dataVal;
+                    break;
+                case 'director':
+                    this.searchCondition.director.logic = logic;
+                    this.searchCondition.director.value = dataVal;
                     break;
                 default:
                     if (mode != '') {

--- a/src/views/IndexTagView.vue
+++ b/src/views/IndexTagView.vue
@@ -101,8 +101,11 @@ const getTagDataList = (tagClass_id: string) => {
     })
 }
 
-const updateDataCondition = (mode: string, logic: EsearchLogic, selectVal: string[]) => {
+const updateDataCondition = (mode: string, logic: EsearchLogic, selectVal: string[], showVal: string[]) => {
     store.searchStore.setSearchData(mode, logic, selectVal);
+    if (mode == 'director' || mode == 'performer') {
+        store.searchStore.setPersonShow(showVal)
+    }
     if (indexUpdateResourcesDataInject) indexUpdateResourcesDataInject([EresUpdate.updateData]);
 }
 


### PR DESCRIPTION
1. 角色标签新增导演集(有导演属性的角色)&文件所属所有角色集(不包括有导演属性的角色)
2. 修改标头搜索条件展示逻辑
3. 角色标签内单选模式下角色重复点击切换选中状态&无演员tag下点击演员跳转到全部tag
4. 自定义标签单选模式下重复点击选项切换选中状态